### PR TITLE
修复复制链接相关问题

### DIFF
--- a/BaiduPanDownload/BaiduPanDownload.csproj
+++ b/BaiduPanDownload/BaiduPanDownload.csproj
@@ -79,6 +79,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/BaiduPanDownload/Forms/Main.cs
+++ b/BaiduPanDownload/Forms/Main.cs
@@ -16,6 +16,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using System.Web;
 
 namespace BaiduPanDownload.Forms
 {
@@ -342,7 +343,7 @@ namespace BaiduPanDownload.Forms
                 }
                 else
                 {
-                    sb.AppendLine($"https://www.baidupcs.com/rest/2.0/pcs/stream?method=download&access_token={Program.config.Access_Token}&path={info.path}");
+                    sb.AppendLine($"https://www.baidupcs.com/rest/2.0/pcs/stream?method=download&access_token={Program.config.Access_Token}&path=" + HttpUtility.UrlEncode($"{info.path}"));
                 }
             }
             try


### PR DESCRIPTION
修复在文件目录含有中文的情况下，复制链接后，在IDM无法下载的问题