### PR TITLE
使用 NuGet 来管理依赖，便于其它开发者编译。

### DIFF
--- a/BaiduPanDownload/BaiduPanDownload.csproj
+++ b/BaiduPanDownload/BaiduPanDownload.csproj
@@ -74,8 +74,9 @@
     <OutputPath>bin\x86\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>J:\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -185,6 +186,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/BaiduPanDownload/packages.config
+++ b/BaiduPanDownload/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
此前的 Newtonsoft.Json 放置于 J 盘根目录，如果有其他开发者 clone 仓库，则会无法编译。现改为使用 NuGet 管理 Newtonsoft.Json 的依赖，于是，只要便宜者联网，即可编译成功。